### PR TITLE
Add button examples and documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2845,6 +2845,50 @@ greet('Developer');</code></pre>
         </div>
 
         <div class="section">
+            <h2>Buttons</h2>
+
+            <h3 class="tw-h3">Style Variants</h3>
+            <div class="code-snippet">
+                &lt;button class=&quot;tw-btn tw-btn-primary&quot;&gt;Primary&lt;/button&gt;<br>
+                &lt;button class=&quot;tw-btn tw-btn-secondary&quot;&gt;Secondary&lt;/button&gt;<br>
+                &lt;button class=&quot;tw-btn tw-btn-accent&quot;&gt;&lt;span class=&quot;tw-mr-2&quot; aria-hidden=&quot;true&quot;&gt;★&lt;/span&gt;Accent Icon&lt;/button&gt;<br>
+                &lt;button class=&quot;tw-btn tw-btn-outline&quot;&gt;Outline&lt;/button&gt;<br>
+                &lt;button class=&quot;tw-btn tw-btn-ghost&quot;&gt;Ghost&lt;/button&gt;<br>
+                &lt;button class=&quot;tw-btn tw-btn-primary&quot; disabled&gt;Primary Disabled&lt;/button&gt;
+            </div>
+            <div class="tw-flex tw-flex-wrap tw-gap-3 tw-items-center">
+                <button class="tw-btn tw-btn-primary">Primary</button>
+                <button class="tw-btn tw-btn-secondary">Secondary</button>
+                <button class="tw-btn tw-btn-accent">
+                    <span class="tw-mr-2" aria-hidden="true">★</span>
+                    Accent Icon
+                </button>
+                <button class="tw-btn tw-btn-outline">Outline</button>
+                <button class="tw-btn tw-btn-ghost">Ghost</button>
+                <button class="tw-btn tw-btn-primary" disabled>Primary Disabled</button>
+            </div>
+
+            <h3 class="tw-h3" style="margin-top: 2rem;">Size Modifiers</h3>
+            <div class="code-snippet">
+                &lt;button class=&quot;tw-btn tw-btn-primary tw-btn-xs&quot;&gt;Extra Small&lt;/button&gt;<br>
+                &lt;button class=&quot;tw-btn tw-btn-primary tw-btn-sm&quot;&gt;Small&lt;/button&gt;<br>
+                &lt;button class=&quot;tw-btn tw-btn-primary&quot;&gt;Base Size&lt;/button&gt;<br>
+                &lt;button class=&quot;tw-btn tw-btn-primary tw-btn-lg&quot;&gt;Large&lt;/button&gt;<br>
+                &lt;button class=&quot;tw-btn tw-btn-secondary tw-btn-xl&quot;&gt;&lt;span class=&quot;tw-mr-2&quot; aria-hidden=&quot;true&quot;&gt;🚀&lt;/span&gt;Extra Large&lt;/button&gt;
+            </div>
+            <div class="tw-flex tw-flex-wrap tw-gap-3 tw-items-center">
+                <button class="tw-btn tw-btn-primary tw-btn-xs">Extra Small</button>
+                <button class="tw-btn tw-btn-primary tw-btn-sm">Small</button>
+                <button class="tw-btn tw-btn-primary">Base Size</button>
+                <button class="tw-btn tw-btn-primary tw-btn-lg">Large</button>
+                <button class="tw-btn tw-btn-secondary tw-btn-xl">
+                    <span class="tw-mr-2" aria-hidden="true">🚀</span>
+                    Extra Large
+                </button>
+            </div>
+        </div>
+
+        <div class="section">
             <h2>Basic Grid</h2>
             <div class="code-snippet">
                 &lt;div class="tw-row"&gt;<br>
@@ -3138,6 +3182,19 @@ greet('Developer');</code></pre>
                     <code class="tw-text-charcoal" style="display: block;">tw-h[1-6]</code>
                     <code class="tw-text-charcoal" style="display: block;">tw-text-[size]</code>
                     <code class="tw-text-charcoal" style="display: block;">tw-font-[weight]</code>
+                </div>
+                <div>
+                    <h3 class="tw-text-secondary tw-text-base" style="margin-bottom: 10px;">Buttons</h3>
+                    <code class="tw-text-charcoal" style="display: block;">tw-btn</code>
+                    <code class="tw-text-charcoal" style="display: block;">tw-btn-primary</code>
+                    <code class="tw-text-charcoal" style="display: block;">tw-btn-secondary</code>
+                    <code class="tw-text-charcoal" style="display: block;">tw-btn-accent</code>
+                    <code class="tw-text-charcoal" style="display: block;">tw-btn-outline</code>
+                    <code class="tw-text-charcoal" style="display: block;">tw-btn-ghost</code>
+                    <code class="tw-text-charcoal" style="display: block;">tw-btn-xs</code>
+                    <code class="tw-text-charcoal" style="display: block;">tw-btn-sm</code>
+                    <code class="tw-text-charcoal" style="display: block;">tw-btn-lg</code>
+                    <code class="tw-text-charcoal" style="display: block;">tw-btn-xl</code>
                 </div>
                 <div>
                     <h3 class="tw-text-secondary tw-text-base" style="margin-bottom: 10px;">Spacing - Margin</h3>


### PR DESCRIPTION
## Summary
- add a Buttons section with live examples for each variant, size, icon-leading, and disabled states
- update the copy/paste snippets to show the combined `.tw-btn` classes used in each example
- extend the Complete Class Reference grid with the new button base, variant, and size utilities

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8a4c91f2c832fbdce5c54a84afc57