### PR TITLE
Remove !important flags from reduced motion overrides

### DIFF
--- a/css/framework.css
+++ b/css/framework.css
@@ -72,10 +72,10 @@ select {
     *,
     *::before,
     *::after {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
-        scroll-behavior: auto !important;
+        animation-duration: 0.01ms;
+        animation-iteration-count: 1;
+        transition-duration: 0.01ms;
+        scroll-behavior: auto;
     }
 }
 


### PR DESCRIPTION
## Summary
- allow prefers-reduced-motion overrides to follow normal cascade rules by removing unnecessary !important flags

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ba6b11ac832fb1babe0d648b4279