### PR TITLE
Remove legacy align-items utilities

### DIFF
--- a/css/framework.css
+++ b/css/framework.css
@@ -1685,14 +1685,6 @@ body {
     .tw-offset-xl-11 { margin-left: 91.666667%; }
 }
 
-/* Legacy vertical alignment utilities (kept for backward compatibility). */
-/* Note: Prefer tw-items-* for new flexbox layouts. */
-.tw-align-items-start { align-items: flex-start; }
-.tw-align-items-end { align-items: flex-end; }
-.tw-align-items-center { align-items: center; }
-.tw-align-items-baseline { align-items: baseline; }
-.tw-align-items-stretch { align-items: stretch; }
-
 /* Order utilities */
 .tw-order-first { order: -1; }
 .tw-order-last { order: 13; }

--- a/index.html
+++ b/index.html
@@ -979,7 +979,7 @@ greet('Developer');</code></pre>
             <h2>Alignment</h2>
             <div class="code-snippet">
                 &lt;div class="tw-row tw-justify-center"&gt;...&lt;/div&gt;<br>
-                &lt;div class="tw-row tw-align-items-center"&gt;...&lt;/div&gt;
+                &lt;div class="tw-row tw-items-center"&gt;...&lt;/div&gt;
             </div>
             <div class="tw-row tw-justify-center">
                 <div class="tw-col-4">
@@ -1002,7 +1002,7 @@ greet('Developer');</code></pre>
                     <div class="demo-box stone">Around</div>
                 </div>
             </div>
-            <div class="tw-row tw-align-items-center" style="height: 150px; background: var(--tw-color-ash-light); border-radius: 8px;">
+            <div class="tw-row tw-items-center" style="height: 150px; background: var(--tw-color-ash-light); border-radius: 8px;">
                 <div class="tw-col-4">
                     <div class="demo-box alt2">Vertically</div>
                 </div>


### PR DESCRIPTION
## Summary
- remove the deprecated tw-align-items utility block from the framework stylesheet
- update alignment examples and documentation snippets to use the tw-items-* classes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8badf6584832fb11c8c8eafb21e52