### PR TITLE
Add grid utilities and CSS Grid demos

### DIFF
--- a/css/framework.css
+++ b/css/framework.css
@@ -448,6 +448,14 @@ select {
 .tw-gap-16 { gap: var(--tw-space-16); }
 .tw-gap-20 { gap: var(--tw-space-20); }
 .tw-gap-24 { gap: var(--tw-space-24); }
+.tw-gap-28 { gap: var(--tw-space-28); }
+.tw-gap-32 { gap: var(--tw-space-32); }
+.tw-gap-36 { gap: var(--tw-space-36); }
+.tw-gap-40 { gap: var(--tw-space-40); }
+.tw-gap-44 { gap: var(--tw-space-44); }
+.tw-gap-48 { gap: var(--tw-space-48); }
+.tw-gap-56 { gap: var(--tw-space-56); }
+.tw-gap-64 { gap: var(--tw-space-64); }
 
 /* Gap X and Y */
 .tw-gap-x-0 { column-gap: var(--tw-space-0); }
@@ -460,6 +468,16 @@ select {
 .tw-gap-x-8 { column-gap: var(--tw-space-8); }
 .tw-gap-x-10 { column-gap: var(--tw-space-10); }
 .tw-gap-x-12 { column-gap: var(--tw-space-12); }
+.tw-gap-x-16 { column-gap: var(--tw-space-16); }
+.tw-gap-x-20 { column-gap: var(--tw-space-20); }
+.tw-gap-x-24 { column-gap: var(--tw-space-24); }
+.tw-gap-x-28 { column-gap: var(--tw-space-28); }
+.tw-gap-x-32 { column-gap: var(--tw-space-32); }
+.tw-gap-x-36 { column-gap: var(--tw-space-36); }
+.tw-gap-x-40 { column-gap: var(--tw-space-40); }
+.tw-gap-x-48 { column-gap: var(--tw-space-48); }
+.tw-gap-x-56 { column-gap: var(--tw-space-56); }
+.tw-gap-x-64 { column-gap: var(--tw-space-64); }
 
 .tw-gap-y-0 { row-gap: var(--tw-space-0); }
 .tw-gap-y-1 { row-gap: var(--tw-space-1); }
@@ -471,6 +489,16 @@ select {
 .tw-gap-y-8 { row-gap: var(--tw-space-8); }
 .tw-gap-y-10 { row-gap: var(--tw-space-10); }
 .tw-gap-y-12 { row-gap: var(--tw-space-12); }
+.tw-gap-y-16 { row-gap: var(--tw-space-16); }
+.tw-gap-y-20 { row-gap: var(--tw-space-20); }
+.tw-gap-y-24 { row-gap: var(--tw-space-24); }
+.tw-gap-y-28 { row-gap: var(--tw-space-28); }
+.tw-gap-y-32 { row-gap: var(--tw-space-32); }
+.tw-gap-y-36 { row-gap: var(--tw-space-36); }
+.tw-gap-y-40 { row-gap: var(--tw-space-40); }
+.tw-gap-y-48 { row-gap: var(--tw-space-48); }
+.tw-gap-y-56 { row-gap: var(--tw-space-56); }
+.tw-gap-y-64 { row-gap: var(--tw-space-64); }
 
 /* Space Between Children (for lists, stacks) */
 .tw-space-x-1 > * + * { margin-left: var(--tw-space-1); }
@@ -565,6 +593,30 @@ select {
 .tw-table-row { display: table-row; }
 .tw-table-cell { display: table-cell; }
 .tw-contents { display: contents; }
+
+/* Grid Template Columns */
+.tw-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.tw-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.tw-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.tw-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.tw-grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.tw-grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.tw-grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.tw-grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.tw-grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.tw-grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.tw-grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.tw-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.tw-grid-cols-none { grid-template-columns: none; }
+
+/* Grid Template Rows */
+.tw-grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.tw-grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.tw-grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.tw-grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.tw-grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.tw-grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+.tw-grid-rows-none { grid-template-rows: none; }
 
 /* Responsive Display */
 @media (min-width: 576px) {

--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
             </div>
             
             <hr class="tw-hr">
-            
+
             <h3 class="tw-h3">Flex Grow & Shrink</h3>
             <div class="tw-row">
                 <div class="tw-col-md-6">
@@ -180,9 +180,39 @@
                     </div>
                 </div>
             </div>
-            
+
             <hr class="tw-hr">
-            
+
+            <h3 class="tw-h3">CSS Grid</h3>
+            <div class="tw-row">
+                <div class="tw-col-md-6">
+                    <h4 class="tw-h4">Column Templates</h4>
+                    <div class="tw-grid tw-grid-cols-3 tw-gap-6 tw-bg-ash tw-p-4 tw-rounded">
+                        <div class="tw-bg-crimson tw-text-white tw-p-3 tw-rounded">1</div>
+                        <div class="tw-bg-crimson tw-text-white tw-p-3 tw-rounded">2</div>
+                        <div class="tw-bg-crimson tw-text-white tw-p-3 tw-rounded">3</div>
+                        <div class="tw-bg-scarlet tw-text-white tw-p-3 tw-rounded">4</div>
+                        <div class="tw-bg-scarlet tw-text-white tw-p-3 tw-rounded">5</div>
+                        <div class="tw-bg-scarlet tw-text-white tw-p-3 tw-rounded">6</div>
+                    </div>
+                    <p class="tw-text-sm tw-text-secondary tw-mt-2"><code>tw-grid tw-grid-cols-3 tw-gap-6</code></p>
+                </div>
+                <div class="tw-col-md-6">
+                    <h4 class="tw-h4">Row Templates & Gaps</h4>
+                    <div class="tw-grid tw-grid-cols-2 tw-grid-rows-3 tw-gap-8 tw-gap-y-32 tw-bg-ash tw-p-4 tw-rounded" style="height: 260px;">
+                        <div class="tw-bg-charcoal tw-text-white tw-p-3 tw-rounded">A</div>
+                        <div class="tw-bg-charcoal tw-text-white tw-p-3 tw-rounded">B</div>
+                        <div class="tw-bg-stone tw-text-white tw-p-3 tw-rounded">C</div>
+                        <div class="tw-bg-stone tw-text-white tw-p-3 tw-rounded">D</div>
+                        <div class="tw-bg-ash-dark tw-text-white tw-p-3 tw-rounded">E</div>
+                        <div class="tw-bg-ash-dark tw-text-white tw-p-3 tw-rounded">F</div>
+                    </div>
+                    <p class="tw-text-sm tw-text-secondary tw-mt-2"><code>tw-grid tw-grid-cols-2 tw-grid-rows-3 tw-gap-8 tw-gap-y-32</code></p>
+                </div>
+            </div>
+
+            <hr class="tw-hr">
+
             <h3 class="tw-h3">Position Utilities</h3>
             <div class="tw-row">
                 <div class="tw-col-md-6">


### PR DESCRIPTION
## Summary
- add utility classes for grid-template-columns and grid-template-rows including none variants
- expand gap, column-gap, and row-gap helpers to cover larger spacing steps
- showcase new grid utilities in the Display & Flexbox section with column and row demos

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8bb46d3a0832f9e98f1ca2866803a