### PR TITLE
Move Google Fonts import to top of framework stylesheet

### DIFF
--- a/css/framework.css
+++ b/css/framework.css
@@ -2,6 +2,8 @@
    CSS RESET & BASE
    ======================================== */
 
+@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&family=Geist:wght@100..900&family=Manrope:wght@200..800&display=swap');
+
 /* Box sizing rules */
 *,
 *::before,
@@ -82,8 +84,6 @@ select {
 /* ========================================
    FONT FACE DECLARATIONS
    ======================================== */
-
-@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&family=Geist:wght@100..900&family=Manrope:wght@200..800&display=swap');
 
 /* ========================================
    SPACING SYSTEM


### PR DESCRIPTION
## Summary
- move the Google Fonts import to the top of the framework stylesheet so the fonts load before other rules

## Testing
- python -m http.server 8000 (manual visual verification of demo page)


------
https://chatgpt.com/codex/tasks/task_e_68d8bdbd94c4832f8511ae544b92a73d