### PR TITLE
Update typography fonts to Google-served families

### DIFF
--- a/css/framework.css
+++ b/css/framework.css
@@ -2,7 +2,7 @@
    FONT FACE DECLARATIONS
    ======================================== */
 
-@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&family=Geist:wght@100..900&family=Manrope:wght@200..800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Manrope:wght@200..800&family=Roboto+Mono:wght@100..700&display=swap');
 
 /* ========================================
    CSS RESET & BASE
@@ -182,9 +182,9 @@ select {
     --tw-shadow-focus: 0 0 0 3px var(--tw-color-crimson-light);
 
     /* Typography System */
-    --tw-font-heading: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    --tw-font-heading: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     --tw-font-body: 'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    --tw-font-mono: 'Geist Mono', 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+    --tw-font-mono: 'Roboto Mono', 'SF Mono', 'Segoe UI Mono', 'Cascadia Code', Menlo, Consolas, 'Courier New', monospace;
 
     --tw-text-xs: 0.75rem;     /* 12px */
     --tw-text-sm: 0.875rem;    /* 14px */

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
             <strong>Framework Features:</strong> 
             <ul style="margin-top: 10px;">
                 <li>✓ Modern CSS Reset with box-sizing and smooth scrolling</li>
-                <li>✓ Typography system with Amulya (headings) and Synonym (body) fonts</li>
+                <li>✓ Typography system with Inter (headings), Manrope (body), and Roboto Mono (code) fonts</li>
                 <li>✓ Complete color system with 7 brand colors, shades, and opacity variants</li>
                 <li>✓ Comprehensive spacing utilities (margin, padding, gap) with consistent scale</li>
                 <li>✓ Display & Flexbox utilities for modern layouts</li>
@@ -709,17 +709,17 @@
             <h2 class="tw-h2">Typography Examples</h2>
             
             <h3 class="tw-h3">Headings</h3>
-            <h1 class="tw-h1">Heading 1 - Amulya Bold</h1>
-            <h2 class="tw-h2">Heading 2 - Amulya Bold</h2>
-            <h3 class="tw-h3">Heading 3 - Amulya Bold</h3>
-            <h4 class="tw-h4">Heading 4 - Amulya Bold</h4>
-            <h5 class="tw-h5">Heading 5 - Amulya Bold</h5>
-            <h6 class="tw-h6">Heading 6 - Amulya Bold</h6>
+            <h1 class="tw-h1">Heading 1 - Inter Bold</h1>
+            <h2 class="tw-h2">Heading 2 - Inter Bold</h2>
+            <h3 class="tw-h3">Heading 3 - Inter Bold</h3>
+            <h4 class="tw-h4">Heading 4 - Inter Bold</h4>
+            <h5 class="tw-h5">Heading 5 - Inter Bold</h5>
+            <h6 class="tw-h6">Heading 6 - Inter Bold</h6>
             
             <hr class="tw-hr">
             
             <h3 class="tw-h3">Body Text</h3>
-            <p>This is a standard paragraph using Synonym Regular font. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+            <p>This is a standard paragraph using Manrope Regular font. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
             
             <p class="tw-lead">This is a lead paragraph with larger, emphasized text. Perfect for introductions and important callouts that need extra attention.</p>
             


### PR DESCRIPTION
## Summary
- replace the Google Fonts import with Inter, Manrope, and Roboto Mono families that are publicly served
- align the typography CSS variables to use the new font stack
- refresh the demo documentation to reference the updated font families

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8cda3979c832fb271eb7bc3e45e72