### PR TITLE
Prefix helper classes for namespace safety

### DIFF
--- a/css/framework.css
+++ b/css/framework.css
@@ -2027,7 +2027,7 @@ a.tw-btn-ghost[aria-disabled="true"] {
     color: var(--tw-color-black-25);
 }
 
-.section {
+.tw-section {
     background: var(--tw-color-white);
     padding: 30px;
     border-radius: 12px;
@@ -2035,7 +2035,7 @@ a.tw-btn-ghost[aria-disabled="true"] {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
-.code-snippet {
+.tw-code-snippet {
     background: var(--tw-color-ash-light);
     padding: 15px;
     border-radius: 6px;
@@ -2046,7 +2046,7 @@ a.tw-btn-ghost[aria-disabled="true"] {
     overflow-x: auto;
 }
 
-.info-box {
+.tw-info-box {
     background: var(--tw-color-white);
     border-left: 4px solid var(--tw-color-crimson);
     padding: 15px;
@@ -2054,7 +2054,7 @@ a.tw-btn-ghost[aria-disabled="true"] {
     border-radius: 4px;
 }
 
-.info-box strong {
+.tw-info-box strong {
     color: var(--tw-color-charcoal);
 }
 
@@ -2079,10 +2079,10 @@ transition: border-color .15s ease, box-shadow .15s ease, background .15s ease;
 .tw-input:focus, .tw-textarea:focus, .tw-select:focus { border-color: var(--tw-color-accent); --tw-ring-color: rgba(167,56,69,.35); box-shadow: 0 0 0 var(--tw-ring-size) var(--tw-ring-color); }
 
 /* States */
-.is-invalid .tw-input, .is-invalid .tw-textarea, .is-invalid .tw-select,
-.tw-input.is-invalid, .tw-textarea.is-invalid, .tw-select.is-invalid {
-border-color: var(--tw-color-error);
---tw-ring-color: rgba(185,74,72,.35);
+.tw-is-invalid .tw-input, .tw-is-invalid .tw-textarea, .tw-is-invalid .tw-select,
+.tw-input.tw-is-invalid, .tw-textarea.tw-is-invalid, .tw-select.tw-is-invalid {
+    border-color: var(--tw-color-error);
+    --tw-ring-color: rgba(185,74,72,.35);
 }
 .tw-field-error { margin-top: 0.375rem; font-size: var(--tw-text-sm); color: var(--tw-color-error); }
 
@@ -2093,10 +2093,10 @@ border-color: var(--tw-color-error);
 /* Switch */
 .tw-switch { position: relative; display: inline-flex; align-items: center; }
 .tw-switch input { position: absolute; opacity: 0; width: 0; height: 0; }
-.tw-switch .track { width: 2.5rem; height: 1.5rem; background: var(--tw-color-ash-light); border-radius: 9999px; position: relative; transition: background .15s ease; }
-.tw-switch .thumb { position: absolute; top: 2px; left: 2px; width: 1.25rem; height: 1.25rem; border-radius: 9999px; background: var(--tw-color-light); box-shadow: var(--tw-shadow-sm); transition: transform .15s ease; }
-.tw-switch input:checked + .track { background: var(--tw-color-accent); }
-.tw-switch input:checked + .track .thumb { transform: translateX(1rem); }
+.tw-switch .tw-track { width: 2.5rem; height: 1.5rem; background: var(--tw-color-ash-light); border-radius: 9999px; position: relative; transition: background .15s ease; }
+.tw-switch .tw-thumb { position: absolute; top: 2px; left: 2px; width: 1.25rem; height: 1.25rem; border-radius: 9999px; background: var(--tw-color-light); box-shadow: var(--tw-shadow-sm); transition: transform .15s ease; }
+.tw-switch input:checked + .tw-track { background: var(--tw-color-accent); }
+.tw-switch input:checked + .tw-track .tw-thumb { transform: translateX(1rem); }
 
 /* Select */
 .tw-select { appearance: none; background-image: linear-gradient(45deg, transparent 50%, currentColor 50%), linear-gradient(135deg, currentColor 50%, transparent 50%); background-position: calc(100% - 18px) calc(50% - 3px), calc(100% - 13px) calc(50% - 3px); background-size: 5px 5px, 5px 5px; background-repeat: no-repeat; }

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
         <h1 class="tw-h1">Complete CSS Framework with TW Prefix</h1>
         <p class="tw-lead">A modern CSS framework featuring a comprehensive reset, professional typography system, rich color palette, spacing utilities, display/flexbox controls, and flexible 12-column grid.</p>
         
-        <div class="info-box">
+        <div class="tw-info-box">
             <strong>Framework Features:</strong> 
             <ul style="margin-top: 10px;">
                 <li>✓ Modern CSS Reset with box-sizing and smooth scrolling</li>
@@ -26,7 +26,7 @@
             </ul>
         </div>
 
-        <div class="section">
+        <div class="tw-section">
             <h2 class="tw-h2">Display & Flexbox Utilities</h2>
             
             <h3 class="tw-h3">Display Types</h3>
@@ -325,7 +325,7 @@
                 </div>
             </div>
 
-        <div class="section">
+        <div class="tw-section">
             <h2 class="tw-h2">Spacing System</h2>
             
             <h3 class="tw-h3">Spacing Scale</h3>
@@ -527,7 +527,7 @@
                 <p class="tw-text-sm tw-text-secondary tw-mt-4">Resize your browser to see the padding change!</p>
             </div>
 
-        <div class="section">
+        <div class="tw-section">
             <h2 class="tw-h2">Color System</h2>
             
             <h3 class="tw-h3">Brand Colors</h3>
@@ -705,7 +705,7 @@
                 </div>
             </div>
 
-        <div class="section">
+        <div class="tw-section">
             <h2 class="tw-h2">Typography Examples</h2>
             
             <h3 class="tw-h3">Headings</h3>
@@ -801,11 +801,11 @@ greet('Developer');</code></pre>
             </div>
         </div>
 
-        <div class="section">
+        <div class="tw-section">
             <h2>Buttons</h2>
 
             <h3 class="tw-h3">Style Variants</h3>
-            <div class="code-snippet">
+            <div class="tw-code-snippet">
                 &lt;button class=&quot;tw-btn tw-btn-primary&quot;&gt;Primary&lt;/button&gt;<br>
                 &lt;button class=&quot;tw-btn tw-btn-secondary&quot;&gt;Secondary&lt;/button&gt;<br>
                 &lt;button class=&quot;tw-btn tw-btn-accent&quot;&gt;&lt;span class=&quot;tw-mr-2&quot; aria-hidden=&quot;true&quot;&gt;★&lt;/span&gt;Accent Icon&lt;/button&gt;<br>
@@ -826,7 +826,7 @@ greet('Developer');</code></pre>
             </div>
 
             <h3 class="tw-h3" style="margin-top: 2rem;">Size Modifiers</h3>
-            <div class="code-snippet">
+            <div class="tw-code-snippet">
                 &lt;button class=&quot;tw-btn tw-btn-primary tw-btn-xs&quot;&gt;Extra Small&lt;/button&gt;<br>
                 &lt;button class=&quot;tw-btn tw-btn-primary tw-btn-sm&quot;&gt;Small&lt;/button&gt;<br>
                 &lt;button class=&quot;tw-btn tw-btn-primary&quot;&gt;Base Size&lt;/button&gt;<br>
@@ -845,9 +845,9 @@ greet('Developer');</code></pre>
             </div>
         </div>
 
-        <div class="section">
+        <div class="tw-section">
             <h2>Basic Grid</h2>
-            <div class="code-snippet">
+            <div class="tw-code-snippet">
                 &lt;div class="tw-row"&gt;<br>
                 &nbsp;&nbsp;&lt;div class="tw-col-4"&gt;...&lt;/div&gt;<br>
                 &nbsp;&nbsp;&lt;div class="tw-col-4"&gt;...&lt;/div&gt;<br>
@@ -867,7 +867,7 @@ greet('Developer');</code></pre>
             </div>
         </div>
 
-        <div class="section">
+        <div class="tw-section">
             <h2>Different Column Sizes</h2>
             <div class="tw-row">
                 <div class="tw-col-12">
@@ -926,9 +926,9 @@ greet('Developer');</code></pre>
             </div>
         </div>
 
-        <div class="section">
+        <div class="tw-section">
             <h2>Responsive Columns</h2>
-            <div class="code-snippet">
+            <div class="tw-code-snippet">
                 &lt;div class="tw-col-12 tw-col-sm-6 tw-col-md-4 tw-col-lg-3"&gt;...&lt;/div&gt;
             </div>
             <div class="tw-row">
@@ -948,9 +948,9 @@ greet('Developer');</code></pre>
             <p class="tw-text-secondary" style="margin-top: 15px;">Resize your browser to see the responsive behavior!</p>
         </div>
 
-        <div class="section">
+        <div class="tw-section">
             <h2>Offset Columns</h2>
-            <div class="code-snippet">
+            <div class="tw-code-snippet">
                 &lt;div class="tw-col-4 tw-offset-4"&gt;...&lt;/div&gt;
             </div>
             <div class="tw-row">
@@ -973,9 +973,9 @@ greet('Developer');</code></pre>
             </div>
         </div>
 
-        <div class="section">
+        <div class="tw-section">
             <h2>Auto Layout Columns</h2>
-            <div class="code-snippet">
+            <div class="tw-code-snippet">
                 &lt;!-- Equal width columns --&gt;<br>
                 &lt;div class="tw-col"&gt;...&lt;/div&gt;<br><br>
                 &lt;!-- Auto width based on content --&gt;<br>
@@ -1005,9 +1005,9 @@ greet('Developer');</code></pre>
             </div>
         </div>
 
-        <div class="section">
+        <div class="tw-section">
             <h2>Alignment</h2>
-            <div class="code-snippet">
+            <div class="tw-code-snippet">
                 &lt;div class="tw-row tw-justify-center"&gt;...&lt;/div&gt;<br>
                 &lt;div class="tw-row tw-items-center"&gt;...&lt;/div&gt;
             </div>
@@ -1045,9 +1045,9 @@ greet('Developer');</code></pre>
             </div>
         </div>
 
-        <div class="section">
+        <div class="tw-section">
             <h2>Ordering</h2>
-            <div class="code-snippet">
+            <div class="tw-code-snippet">
                 &lt;div class="tw-col-4 tw-order-3"&gt;First in HTML&lt;/div&gt;<br>
                 &lt;div class="tw-col-4 tw-order-1"&gt;Second in HTML&lt;/div&gt;<br>
                 &lt;div class="tw-col-4 tw-order-2"&gt;Third in HTML&lt;/div&gt;
@@ -1065,9 +1065,9 @@ greet('Developer');</code></pre>
             </div>
         </div>
 
-        <div class="section">
+        <div class="tw-section">
             <h2>No Gutters</h2>
-            <div class="code-snippet">
+            <div class="tw-code-snippet">
                 &lt;div class="tw-row tw-no-gutters"&gt;...&lt;/div&gt;
             </div>
             <div class="tw-row tw-no-gutters">
@@ -1083,7 +1083,7 @@ greet('Developer');</code></pre>
             </div>
         </div>
 
-        <div class="section">
+        <div class="tw-section">
             <h2>Complete Class Reference</h2>
             <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin-top: 20px;">
                 <div>


### PR DESCRIPTION
## Summary
- prefix the section, info box, and code snippet helpers with the `tw-` namespace in the framework stylesheet
- update demo markup to use the new helper class names
- align remaining helper selectors such as invalid states and switch parts with the prefixed naming convention

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8ce5b3454832fa847ad5c6bb2c05a